### PR TITLE
Add "types" field to spectypes "exports" in package.json

### DIFF
--- a/packages/spectypes/package.json
+++ b/packages/spectypes/package.json
@@ -10,6 +10,7 @@
   "react-native": "./dist/mjs/index.js",
   "exports": {
     ".": {
+      "types": "./dist/dts/index.d.ts",
       "require": "./dist/cjs/index.js",
       "default": "./dist/mjs/index.js"
     },


### PR DESCRIPTION
For more details on this, see https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

This is necessary to prevent an error of the form:
```
Could not find a declaration file for module 'spectypes'. '[path]/node_modules/spectypes/dist/mjs/index.js' implicitly has an 'any' type.
  There are types at '[path]/node_modules/spectypes/dist/dts/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'spectypes' library may need to update its package.json or typings.
```
as of Typescript 5.